### PR TITLE
feat(mod): auto-ban users for image spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # -Rai-
-Discord bot for Discord language servers (Python).  Some key features: 
+
+Discord bot for Discord language servers (Python). Some key features:
+
 - Extensive logging of joins, leaves, bans, deletes, edits, reaction removes, and invites that people use to join a server
-- A report room for users to make either anonymous reports to mods or enter a mod report chat room to discuss an issue.  Designed to eliminate the need for private messages completely from mod business.  
+- A report room for users to make either anonymous reports to mods or enter a mod report chat room to discuss an issue. Designed to eliminate the need for private messages completely from mod business.
 - A smart message prune/clear command which takes a message ID as input so you don't have to count messages
 - Configurable reaction requirement to enter a server
 - Super watchlist for when you have raiders who are repeatedly making accounts and spamming gore/porn/etc.
-- A questions module to manage the questions queue of a server.  Mainly, for people who ask hard questions that get swept away in the channel, this module will help them make sure their question eventually gets answered.
+- A questions module to manage the questions queue of a server. Mainly, for people who ask hard questions that get swept away in the channel, this module will help them make sure their question eventually gets answered.
 - Options module for easy configuration of options
 - Unlimited duration timed mutes and bans.
 - Stats module for showing most active users in the server and per channel for the last month.
@@ -19,6 +21,7 @@ A guide on effective moderation is here: https://github.com/ryry013/Rai/wiki/How
 Questions to my Discord account: Ryry013#9234
 
 # Commands
+
 List of commands for Rai bot.
 
 - [General](#general)
@@ -39,173 +42,204 @@ List of commands for Rai bot.
 - [Logging](#logging)
 - [Japanese Study Commands](#japanese-study-commands)
 
-
 ## General
+
 These are usable by anyone, mostly just for fun or light general utility.
+
 - **`;chlb (#other_channel_name)`** Shows the leaderboard for the current channel (or another channel if you specify one)
-- **`;eraser`** Erases the last character of your nickname, supposedly a :pencil:, made in conjunction with ;pencil.  Mostly a joke command
+- **`;eraser`** Erases the last character of your nickname, supposedly a :pencil:, made in conjunction with ;pencil. Mostly a joke command
 - **`;github`** Shows my GitHub page
 - **`;invite`** Gives an invite to invite Rai to your server. Currently not everyone can use this command.
-- **`;jisho <text>`** Links to a Jisho search of the text you cite.  Useful for people who ask questions that could be answered with a simple jisho search.
+- **`;jisho <text>`** Links to a Jisho search of the text you cite. Useful for people who ask questions that could be answered with a simple jisho search.
 - **`;lb`** Shows the guild leaderboard.
 - **`;nadeko_flip_test`** A command to simulate the Martingale strategy for Nadeko's coin flip gambling module (alias `;nft`)
 - **`;ping`** Doesn't actually perform a ping test but still a good test
-- **`;pencil`** Adds a :pencil: to the end of your name to signify that you wish to be corrected.  See ;eraser
+- **`;pencil`** Adds a :pencil: to the end of your name to signify that you wish to be corrected. See ;eraser
 - **`;punch`** The first command I made with cogs, just a test, try it
 - **`;randomWalk`** <number> Generates a random walk plot, try it
 - **`;report`** Starts the dialogue in PM for entering the report room (server admins must run the setup command first)
 - **`;ryan`** Posts an invite link to this page/my testing server
 - **`;u`** Shows your profile information
 
-
-  
 ## Admin Commands
-The commands in this module are only usable by users with either the `Administrator` privelege in a server, or if they have the mod role set in the next command.  **Most of these commands can be manipulated easier by typing `;options` and using the menu that comes up.**
+
+The commands in this module are only usable by users with either the `Administrator` privelege in a server, or if they have the mod role set in the next command. **Most of these commands can be manipulated easier by typing `;options` and using the menu that comes up.**
 
 #### Setting the mod channel
-Important messages from the bot will go here.  This channel doesn't have to actually be your mod channel, just in the channel you want important notifications to go, type:
+
+Important messages from the bot will go here. This channel doesn't have to actually be your mod channel, just in the channel you want important notifications to go, type:
+
 - **`;set_mod_channel`** Sets the current channel as the mod channel
 
-#### Setting the mod role  
-- **`;set_mod_role [role name]`** Sets the mod role for the server.  Type the name of the role exactly in [role name].
-- **`;set_submod_role [role name]`** If you want to optionally allow a secondary role to be able to mute users, use this.  Otherwise, `;mute` will default to the main mod role.
+#### Setting the mod role
+
+- **`;set_mod_role [role name]`** Sets the mod role for the server. Type the name of the role exactly in [role name].
+- **`;set_submod_role [role name]`** If you want to optionally allow a secondary role to be able to mute users, use this. Otherwise, `;mute` will default to the main mod role.
 
 #### Setting the submod role
-This is an optional feature.  Submods can 1) ban users within one hour of them joining (for trolls spamming porn or something when there are no mods online), 2) mute users, 3) delete messages using a special command, and the log of the message will be left in the submod channel, and 4) pin messages using a special command.
+
+This is an optional feature. Submods can 1) ban users within one hour of them joining (for trolls spamming porn or something when there are no mods online), 2) mute users, 3) delete messages using a special command, and the log of the message will be left in the submod channel, and 4) pin messages using a special command.
+
 - **`;set_submod_channel`** Sets the current channel as the submod channel
 
-#### Setting the submod role  
-- **`;set_submod_role [role name]`** Sets the mod role for the server.  Type the name of the role exactly in [role name].
-  
+#### Setting the submod role
+
+- **`;set_submod_role [role name]`** Sets the mod role for the server. Type the name of the role exactly in [role name].
+
 #### Setting a custom prefix
+
 - **`;set_prefix [prefix]`** Sets a custom prefix, for example, `;set_prefix !`
   - **`<prefix>set_prefix reset`** Resets the prefix to `;`
-  
+
 #### Ban/Mute/Warning + Modlog
-- **`;modlog|warnlog [user]`** Views the modlog for a user.  This contains all incidents of them being warned or muted, and is helpful for times when they ask "What did I do?!?!? You never warned me!!"  Use silent warnings as a form of logging small incidents.
-- **`;warnlog delete|del <user> <index>`** Deletes an entry from someone's warnlog.  Index refers to the number in the list when you call their `;warnlog`.  Example: `;warnlog delete 202995638860906496 2`.
-- **`;warnlog edit|reason <user> <index> <reason>`** Edits the reason for an entry.  Index refers to the number in the list when you call their `;warnlog`.  You can also substitute `;warnlog reason` --> `;reason`.  Example: `;reason 202995638860906496 2 Trolling in voice`.
-- **`;ban [time] <user> [reason]`** Bans a user for an optional amount of time with an optional reason.  Examples:
-  - `;ban @Ryry013` Bans me indefinitely.  
+
+- **`;modlog|warnlog [user]`** Views the modlog for a user. This contains all incidents of them being warned or muted, and is helpful for times when they ask "What did I do?!?!? You never warned me!!" Use silent warnings as a form of logging small incidents.
+- **`;warnlog delete|del <user> <index>`** Deletes an entry from someone's warnlog. Index refers to the number in the list when you call their `;warnlog`. Example: `;warnlog delete 202995638860906496 2`.
+- **`;warnlog edit|reason <user> <index> <reason>`** Edits the reason for an entry. Index refers to the number in the list when you call their `;warnlog`. You can also substitute `;warnlog reason` --> `;reason`. Example: `;reason 202995638860906496 2 Trolling in voice`.
+- **`;ban [time] <user> [reason]`** Bans a user for an optional amount of time with an optional reason. Examples:
+  - `;ban @Ryry013` Bans me indefinitely.
   - `;ban 1d2h @Ryry013` Bans me for 1 day and 2 hours.
   - `;ban @Ryry013 for being mean` Bans me indefinitely for being mean.
-- **`;mute [time] <user>`** Mutes a user from all text and voice chat.  Similar usage to the above `;ban` command.
-- **`;warn [user] <reason> <-s>`** Warns a user and sends them a PM.  Add `-s` into the reason to make it not send the PM (makes it silent).  Use this for either warning the user when they've done something, or use the silent warnings to log incidents 
-  
+- **`;mute [time] <user>`** Mutes a user from all text and voice chat. Similar usage to the above `;ban` command.
+- **`;warn [user] <reason> <-s>`** Warns a user and sends them a PM. Add `-s` into the reason to make it not send the PM (makes it silent). Use this for either warning the user when they've done something, or use the silent warnings to log incidents
+
 #### Captcha to enter a server
-Sets up a requirement to react to a message with a checkmark to enter a server / get a role.  Follow these steps:
-1) First, do `;captcha toggle` to setup the module
-2) Then, do `;captcha set_channel` in the channel you want to activate it in.
-3) Then, do `;captcha set_role <role name>` to set the role you wish to add upon them captchaing.
-4) Finally, do `;captcha post_message` to post the message people will react to.
-  
+
+Sets up a requirement to react to a message with a checkmark to enter a server / get a role. Follow these steps:
+
+1. First, do `;captcha toggle` to setup the module
+2. Then, do `;captcha set_channel` in the channel you want to activate it in.
+3. Then, do `;captcha set_role <role name>` to set the role you wish to add upon them captchaing.
+4. Finally, do `;captcha post_message` to post the message people will react to.
+
 #### Clear/prune messages
-**`;clear [number of messages] (user) (message_id)`** *(aliases `;purge`, `;prune`)* A clear/prune command with LOTS of different ways to use it.  For a number of messages above 100, the bot will ask for a confirmation before starting the deleting.  
 
-The `user` field can be an ID, nickname, username, or mention.  It will only delete messages from that user.  
+**`;clear [number of messages] (user) (message_id)`** _(aliases `;purge`, `;prune`)_ A clear/prune command with LOTS of different ways to use it. For a number of messages above 100, the bot will ask for a confirmation before starting the deleting.
 
-The `message_id`, if specified, will start a prune that deletes all messages past the specified message.  See the following examples.
+The `user` field can be an ID, nickname, username, or mention. It will only delete messages from that user.
 
-Typical usage:  
-- **`;clear 50`** Clears the last 50 messages in the channel  
-- **`;clear 50 USER_ID`** In the last 50 messages in the channel, deletes all messages from specified user.  
-- **`;clear 50 Ryry013`** You can also search by username/nickname.  This is risky because the bot might find the wrong person.  
-- **`;clear 50 USER_ID MESSAGE_ID`** Deletes all messages from a specified user that also fall after the specified message (The bot will delete 50 messages or all messages below the specified message, whichever is *less*)
+The `message_id`, if specified, will start a prune that deletes all messages past the specified message. See the following examples.
 
-Special syntax:  
-- **`;clear MESSAGE_ID`** A syntax where you only specify a message ID.  It will default to a max of 100 messages at the most, and it will delete all messages from all users past the specified message id.
+Typical usage:
+
+- **`;clear 50`** Clears the last 50 messages in the channel
+- **`;clear 50 USER_ID`** In the last 50 messages in the channel, deletes all messages from specified user.
+- **`;clear 50 Ryry013`** You can also search by username/nickname. This is risky because the bot might find the wrong person.
+- **`;clear 50 USER_ID MESSAGE_ID`** Deletes all messages from a specified user that also fall after the specified message (The bot will delete 50 messages or all messages below the specified message, whichever is _less_)
+
+Special syntax:
+
+- **`;clear MESSAGE_ID`** A syntax where you only specify a message ID. It will default to a max of 100 messages at the most, and it will delete all messages from all users past the specified message id.
 
 #### Report room
+
 This command module, while it's still in the bot, has mainly been replaced by the DMModbot bot on my repo.
 ⠀
+
 #### Super_watch lists: an anti-raid tool
 
-Super_watch  
-*(alias `;sw`, `;superwatch`)*
-If you're being raided by someone who is repeatedly making multiple accounts to rejoin and spam, use this on the accounts that you think are the raiders. It will notify you **every** time they send a message, which obviously would normally be annoying, but it's helpful if you really do think they're a troll and you're just waiting for them to send their bad message, and you don't know where they'll send it to. 
-- **`;super_watch add [id/name]`** Adds someone to the watch list.  Every time they send a message anywhere, the bot will make a post notifying the mods.   
-- **`;sw remove [id/name]`** Removes someone from the watch list.  
-- **`;sw list`** Shows the current list of super-watched people.  
+Super*watch  
+*(alias `;sw`, `;superwatch`)\_
+If you're being raided by someone who is repeatedly making multiple accounts to rejoin and spam, use this on the accounts that you think are the raiders. It will notify you **every** time they send a message, which obviously would normally be annoying, but it's helpful if you really do think they're a troll and you're just waiting for them to send their bad message, and you don't know where they'll send it to.
+
+- **`;super_watch add [id/name]`** Adds someone to the watch list. Every time they send a message anywhere, the bot will make a post notifying the mods.
+- **`;sw remove [id/name]`** Removes someone from the watch list.
+- **`;sw list`** Shows the current list of super-watched people.
 - **`;sw set`** Set the channel you wish the messages to be posted to
 
-Super_voicewatch  
-*(aliases `;svw`, `;supervoicewatch`)*
-If you've received reports for a user causing problems in voice, use this to notify the mods whenever that user joins voice so you can immediately go listen and hopefully confirm the reports.  
-- **`;super_voicewatch`** Sets-up the module/displays help for it.  
-- **`;svw add [USER]`** **`;svw remove [USER]`** Adds/removes a user from the list  
+Super*voicewatch  
+*(aliases `;svw`, `;supervoicewatch`)\_
+If you've received reports for a user causing problems in voice, use this to notify the mods whenever that user joins voice so you can immediately go listen and hopefully confirm the reports.
+
+- **`;super_voicewatch`** Sets-up the module/displays help for it.
+- **`;svw add [USER]`** **`;svw remove [USER]`** Adds/removes a user from the list
 - **`;svw list`** Shows a list of all users on the list currently
 
 #### Word filter for new users
+
 Type `;wordfilter` to bring up a menu that will configure settings for punishments against new users who say some word or phrase you choose within their first minutes in the server. For example, you can set it to mute or ban users who say the n-word if it's their first five minutes in the server. The timing requirement allows you to be more strict in the filter compared to a normal user for which you wouldn't want to subject to the same strict filters.
 
 #### Antispam
-Setup antispam to [mute/kick/ban] users who spam the same message [x] times in [y] seconds. For example, mute users who send the same message 10 times in 10 seconds. Type just `;antispam` to enter the configuration menu. 
+
+Setup antispam to [mute/kick/ban] users who spam the same message [x] times in [y] seconds. For example, mute users who send the same message 10 times in 10 seconds. Type just `;antispam` to enter the configuration menu.
 
 #### Antispam for Images
-Monitor image messages across multiple channels to detect and prevent spam, especially from compromised or hacked accounts. This module tracks how many images users send within a set timeframe, automatically timing them out and logging alerts with evidence.
-| Parameter   | Description                                    | Default |
+
+Monitor image messages across multiple channels to detect and prevent spam, especially from compromised or hacked accounts. This module tracks how many images users send within a set timeframe, automatically times them out for 1 week, logs alerts with evidence, and bans them, providing instructions to appeal.
+| Parameter | Description | Default |
 | ----------- | ---------------------------------------------- | ------- |
-| `channel`   | Channel where image spam alerts will be sent   | —       |
-| `limit`     | Number of images required to trigger detection | `2`     |
-| `timeframe` | Time window (in seconds) to detect image spam  | `10`    |
-| `timeout`   | Duration of the mute (in minutes)              | `60`    |
+| `channel` | Channel where image spam alerts will be sent | — |
+| `limit` | Number of images required to trigger detection | `2` |
+| `timeframe` | Time window (in seconds) to detect image spam | `10` |
 
 Type `/spam_enable` to enable the image spam module, or `/spam_disable` to turn it off.
 
 #### Invite link/amazingsexdating spam auto-banning
+
 This command module has been deleted since the release of Discord's automod module. This is the [list of filter terms](https://mystb.in/DramaticallySharedSecretariat) I currently use for my servers from recent bot spammers.
 
 #### Welcome messages
+
 Welcome new users when they join the server
-- **`;welcome_message`** Toggles the posting of welcome messages, while keeping the rest of the settings the same  
-- **`;welcome_message set_message <message>`** Sets the welcome message to whatever you put inside <message> (without <>).  
-- **`;welcome_message set_channel`** Sets the channel you send this command in to be the channel that welcome messages are posted into  
-- **`;welcome_message show_message`** Shows the currently set welcome message  
-  
+
+- **`;welcome_message`** Toggles the posting of welcome messages, while keeping the rest of the settings the same
+- **`;welcome_message set_message <message>`** Sets the welcome message to whatever you put inside <message> (without <>).
+- **`;welcome_message set_channel`** Sets the channel you send this command in to be the channel that welcome messages are posted into
+- **`;welcome_message show_message`** Shows the currently set welcome message
+
 Formatting variables: Put any of these in the welcome message to have them replaced with the relevant information in the actual welcome.
+
 - `$NAME` → The name of the user (not a mention, just plaintext)
 - `$USERMENTION$` → A ping/mention to the user
 - `$SERVER$` → The name of the server
 
 #### Stats
-Will keep track of the top posters in a server, and also per channel.  Give users their most-talked-in channels.
+
+Will keep track of the top posters in a server, and also per channel. Give users their most-talked-in channels.
+
 - **`;stats`** Enable/disable the stats module
-- **`;stats hide`** Type this in your mod channels.  It hides these channels from showing up in the `;u` command in public channels.  Typing `;u` in one of the specified mod channels will include all the information for the mod channels.  
-- **`;u (member)`** Shows your profile information.  Leave the `member` field blank to look up yourself.
+- **`;stats hide`** Type this in your mod channels. It hides these channels from showing up in the `;u` command in public channels. Typing `;u` in one of the specified mod channels will include all the information for the mod channels.
+- **`;u (member)`** Shows your profile information. Leave the `member` field blank to look up yourself.
 - **`;lb`** Shows the guild leaderboard.
 - **`;chlb (#other_channel_name)`** Shows the leaderboard for the current channel (or another channel if you specify one)
-- **`;vc|v|vclb|vlb|voicechat`** Lots of names for this command.  Prints a leaderboard of who has the most time in voice.
-- **`;uchannels|uc (member)`** Shows a full list of channel data for a user.  Leave the `member` field blank to look up yourself.
-- **`;alb`** Shows a leaderboard of user *activity* in the server. This is differnet from `;lb` in that it doesn't count just number of messages, but instead gives a user five activity points to the leaderboard for each new message in a unique channel every 60 seconds.
+- **`;vc|v|vclb|vlb|voicechat`** Lots of names for this command. Prints a leaderboard of who has the most time in voice.
+- **`;uchannels|uc (member)`** Shows a full list of channel data for a user. Leave the `member` field blank to look up yourself.
+- **`;alb`** Shows a leaderboard of user _activity_ in the server. This is differnet from `;lb` in that it doesn't count just number of messages, but instead gives a user five activity points to the leaderboard for each new message in a unique channel every 60 seconds.
 - **`;activity`** Shows a graph of the user's activity per day over the last month.
 
 #### Self-Assignable Roles
-Modeled after Nadeko's self-assignable role system.  Allows users to assign themselves roless.
+
+Modeled after Nadeko's self-assignable role system. Allows users to assign themselves roless.
+
 - **`;asar <role_name>`** Assigns a self-assignable role.
 - **`;lsar <page_number>`** Lists all self-assignable roles.
 - **`;iam <role_name>`** Assign a role to yourself.
 - **`;iamnott|iamn <role_name>`** Remove a role from yourself.
 
 #### Chinese server only
+
 - **`;hardcore`** Posts a message in that channel with a reaction for people to click to assign hardcore mode to themselves
 - **`;hardcore ignore`** Adds or removes a channel from the list of channels ignored by hardcore mode
-` **`;post_rules`** Updates the rules according to the Google Doc pinned in the mod channel.
+  ` **`;post_rules`\*\* Updates the rules according to the Google Doc pinned in the mod channel.
 
 #### Japanese server only
-- **`;swap`** Swaps the names and positions of JHO and JHO2.  Use this if JHO is particularly active and you want to move the welcome messages to JHO2.  Or as a fun prank to confuse people.
-- **`;ultrahardcore on`** *(Japanese server only) (Alias: `;uhc`)* Enters ultra hardcore mode, you must talk to a mod to remove it, which they can do by `;uhc <user/id>`.  
-- **`;ultrahardcore [NAME / ID]`** *(alias `;uhc`) *Removes a user from ultra hardcore mode 
+
+- **`;swap`** Swaps the names and positions of JHO and JHO2. Use this if JHO is particularly active and you want to move the welcome messages to JHO2. Or as a fun prank to confuse people.
+- **`;ultrahardcore on`** _(Japanese server only) (Alias: `;uhc`)_ Enters ultra hardcore mode, you must talk to a mod to remove it, which they can do by `;uhc <user/id>`.
+- **`;ultrahardcore [NAME / ID]`** *(alias `;uhc`) *Removes a user from ultra hardcore mode
 - **`;ultrahardcore ignore`** Adds the channel that you send this message in to the whitelist for ignored channels for ultra hardcore mode.
   - **`;uhc list`** Lists the people in ultra hardcore mode.
   - **`;uhc explanation`** Posts an explanation in English about hardcore mode to help explain to other people why you can't speak English if they don't understand your attempts to explain it to them in Japanese
-  -- **`;uhc lb`** Shows a leaderboard of who has had UHC for the longest.
+    -- **`;uhc lb`** Shows a leaderboard of who has had UHC for the longest.
 
 ## Logging
-Part of the admin commands, but deserves it's own section.  
+
+Part of the admin commands, but deserves it's own section.
 
 There's a lot of logging that can be done, and the setup for all of them are pretty much all referring to the same code, so they're all the same.
 
 The things you can log are:
+
 - Deleted / edited messages (`;deletes`, `;edits`)
 - Joins / leaves (`;welcomes`/`;joins`, `;leaves`)
   - Detection of which invite link a user used to join the server (`;invites`)
@@ -220,7 +254,9 @@ To set the channel that the logging gets posted in, type the name of the module,
 
 For examples/screenshots of all the loggings, try it yourself or see my testing server.
 ⠀
+
 ## Questions
+
 The questions module has been replaced by Discord's forum feature.
 
 ## Japanese Study Commands
@@ -237,4 +273,4 @@ I have various commands that I've built over time to help Japanese studiers:
 - `;jisho <text>` Gives a link to Jisho for a word. Helpful for people who say "what does X mean" and you want to teach them how to fish.
 - `;diff <word1> <word2>` Gives google search results which will probably show the difference between two words you input. This literally just does a Google search so use it for people who ask the question "what's the difference between X and Y", and encourage them to do their own Google searches in the future before coming to ask the simple question.
 
-- `;sc <word1> <word2> ...` Does a *search compare* lookup for two or more exact phrases and tells you the number of hits from different websites.
+- `;sc <word1> <word2> ...` Does a _search compare_ lookup for two or more exact phrases and tells you the number of hits from different websites.

--- a/cogs/image_spam.py
+++ b/cogs/image_spam.py
@@ -9,83 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from PIL import Image
 from io import BytesIO
-
-class SolvedView(discord.ui.View):
-    """
-    Discord UI View that provides a button to mark an image spam alert as solved.
-
-    When the button is pressed by a moderator, the alert embed is updated,
-    the associated thread is deleted, and the alert lock is released so the
-    user can be flagged again in the future.
-    """
-    def __init__(self, cog, thread, key):
-        """
-        Initialize the SolvedView.
-
-        Parameters:
-        - cog: Reference to the ImageSpam cog.
-        - thread: The Discord thread containing evidence images.
-        - key: Tuple (guild_id, user_id) used to track active alerts.
-        """
-        super().__init__(timeout=None)
-        self.cog = cog
-        self.thread = thread
-        self.key = key
-
-    @discord.ui.button(
-        label="Mark as solved",
-        style=discord.ButtonStyle.secondary,
-        custom_id="solved_button"
-    )
-    async def solved(self, interaction: discord.Interaction, button: discord.ui.Button):
-        """
-        Callback executed when the 'Mark as solved' button is pressed.
-
-        - Updates the alert embed status
-        - Deletes the evidence thread
-        - Releases the alert lock for the user
-        """
-        if not interaction.user.guild_permissions.moderate_members:
-            await interaction.response.send_message(
-                "You don't have permission to do this.",
-                ephemeral=True
-            )
-            return
-
-        embed = interaction.message.embeds[0]
-
-        for i, field in enumerate(embed.fields):
-            if field.name == "Status":
-                embed.set_field_at(
-                    i,
-                    name="Status",
-                    value="✅ Solved",
-                    inline=True
-                )
-                break
-
-        embed.add_field(
-            name=" ",
-            value=(
-                f"Solved by {interaction.user.mention} · "
-                f"{datetime.now().strftime('%d/%m/%Y %H:%M')}"
-            ),
-            inline=False
-        )
-
-        button.disabled = True
-        await interaction.response.edit_message(embed=embed, view=self)
-
-        if self.thread:
-            try:
-                await self.thread.delete()
-            except Exception as e:
-                print("Error while solving alert:", e)
-
-        # Reseting lock after solving the alert
-        if self.key in self.cog.active_alerts:
-            self.cog.active_alerts[self.key]["lock_alert"] = None
-
+from .utils import helper_functions as hf
 
 class ImageSpam(commands.Cog):
     """
@@ -166,7 +90,6 @@ class ImageSpam(commands.Cog):
         channel="The text channel where alerts for flagged users will be sent",
         limit="The number of images required to trigger spam detection",
         timeframe="The time interval (in seconds) between images used to detect spam",
-        timeout="The duration (in minutes) the user will be punished for spamming"
     )
     @app_commands.default_permissions(administrator=True)
     async def spam_enable(
@@ -175,7 +98,6 @@ class ImageSpam(commands.Cog):
         channel: discord.TextChannel,
         limit: int = 2,
         timeframe: int = 10,
-        timeout: int = 60
     ):
         """
         Enables image spam detection for the guild and stores configuration.
@@ -195,8 +117,8 @@ class ImageSpam(commands.Cog):
             "channel": channel.id,
             "limit": limit,
             "timeframe": timeframe,
-            "timeout": timeout
         })
+        config.pop("timeout", None)
 
         embed = discord.Embed(
             title="⚠️ Image Spam Module",
@@ -206,7 +128,6 @@ class ImageSpam(commands.Cog):
 
         embed.add_field(name="Limit", value=f"{limit} images", inline=True)
         embed.add_field(name="Timeframe", value=f"{timeframe} seconds", inline=True)
-        embed.add_field(name="Timeout", value=f"{timeout // 60} hour(s)", inline=True)
 
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
@@ -240,10 +161,10 @@ class ImageSpam(commands.Cog):
         Listens for new messages and detects image spam behavior.
 
         If spam is detected:
-        - Times out the user
         - Sends an alert embed
         - Collects image evidence
         - Deletes spam messages
+        - Ban the user
         """
         if message.author.bot or not message.guild:
             return
@@ -260,7 +181,9 @@ class ImageSpam(commands.Cog):
         if not images:
             return
 
-        key = (message.guild.id, message.author.id)
+        member = message.author
+
+        key = (message.guild.id, member.id)
         now = time.time()
 
         self.image_spam.setdefault(key, [])
@@ -289,12 +212,14 @@ class ImageSpam(commands.Cog):
             if not alert_channel:
                 return
 
-            until = datetime.now(timezone.utc) + timedelta(minutes=config["timeout"])
             bot_member = message.guild.me
 
+            timeout_seconds = 7 * 24 * 60 * 60  # Timeout 1 week
+            until = datetime.now(timezone.utc) + timedelta(seconds=timeout_seconds)
+
             try:
-                if bot_member.guild_permissions.moderate_members and message.author.top_role < bot_member.top_role:
-                    await message.author.timeout(until, reason="Automated detection of image spam")
+                if bot_member.guild_permissions.moderate_members and member.top_role < bot_member.top_role:
+                    await member.timeout(timedelta(seconds=timeout_seconds))
             except Exception:
                 pass
 
@@ -309,10 +234,10 @@ class ImageSpam(commands.Cog):
 
             embed = discord.Embed(
                 title="⚠️ Image Spam Detected",
-                description=f"{message.author.mention} was **timed out** <t:{timed_time}:R> for **{config['timeout'] // 60} hour(s)**",
+                description=f"-# {message.author.mention} was timed out <t:{timed_time}:R> for 1 week.",
                 color=discord.Color.blue()
             )
-            embed.add_field(name="Status", value="❌ Unsolved", inline=True)
+            embed.add_field(name="Status", value="⌛ Banning...", inline=True)
             embed.add_field(name="Rate", value=f"{total_images} images / {config['timeframe']} seconds", inline=True)
             embed.add_field(name="Top Spammed", value=top_channels_mentions, inline=True)
             embed.set_footer(
@@ -334,10 +259,6 @@ class ImageSpam(commands.Cog):
             thread = await alert_msg.create_thread(name=f"Spam by {message.author.name} - {message.author.id}")
             await asyncio.gather(*(thread.send(file=f) for f in files))
 
-            await alert_msg.edit(view=SolvedView(self, thread, key))
-
-            self.active_alerts[key]["lock_alert"] = alert_msg.id
-
             # Delete spam messages
             for _, ch, msg_id, _ in self.image_spam[key]:
                 try:
@@ -348,18 +269,37 @@ class ImageSpam(commands.Cog):
                 except:
                     pass
 
-            self.image_spam[key] = []
-
+            # Send evidence
             try:
+                evidence_msg = None
                 await asyncio.sleep(1.5)
                 evidence = await self.thread_to_image(thread)
                 if evidence:
-                    await alert_channel.send(
-                        content="**Evidence**",
+                    evidence_msg = await alert_channel.send(
+                        content="-# Evidence",
                         file=discord.File(evidence, filename=f"{message.author.id}_evidence_spam.png")
                     )
             except Exception as e:
                 print("Evidence generation failed:", e)
+
+            # Ban user
+            try: 
+                if bot_member.guild_permissions.moderate_members and member.top_role < bot_member.top_role: 
+                    await hf.auto_ban(member=member, evidence_msg=evidence_msg)
+            except Exception as e:
+                print("Banned failed:", e)
+
+            # Delete thread
+            try:
+                await thread.delete()
+            except Exception:
+                pass
+
+            embed.set_field_at(0, name="Status", value=f"✅ Banned")
+            await alert_msg.edit(embed=embed)
+
+            self.active_alerts[key]["lock_alert"] = alert_msg.id
+            self.image_spam[key] = []
 
 async def setup(bot: commands.Bot):
     """

--- a/cogs/utils/helper_functions.py
+++ b/cogs/utils/helper_functions.py
@@ -416,6 +416,72 @@ def add_to_modlog(ctx: Optional[commands.Context],
                                                 'jump_url': jump_url})
     return config
 
+async def auto_ban(
+    member: discord.Member,
+    reason: str | None = None,
+    length: tuple[int, int] | None = None,
+    delete_message_days: int = 1,
+    silent: bool = False,
+    evidence_msg: discord.Message | None = None,
+):
+    """
+    Automatically bans a member from the server.
+
+    Parameters:
+        member: The discord.Member to ban.
+        reason: Optional reason for the ban. If None, uses default hacked account reason.
+        length: Optional duration of the ban as (days, hours).
+        delete_message_days: Number of days of messages to delete.
+        silent: If True, no DM will be sent to the user.
+        evidence_msg: Optional discord.Message containing the evidence for the modlog.
+    """
+
+    default_reason = (
+        "Hacked account. Please appeal AFTER you've:\n"
+        "1) Changed your account password\n"
+        "2) Enabled two-factor authentication on your account\n"
+        "3) Removed all authorized apps from your Discord profile settings\n\n"
+        "-# If this was a mistake, please submit an appeal ticket: https://discord.gg/pnHEGPah8X"
+    )
+    dm_reason = reason or default_reason
+    modlog_reason = dm_reason
+    if evidence_msg:
+        modlog_reason += f"\n- [Evidence](<{evidence_msg.jump_url}>)"
+
+    this_user_modlog = here.bot.db['modlog'].get(str(member.id), [])
+    for entry in this_user_modlog:
+        if entry[1] == modlog_reason:
+            return
+
+    if not silent:
+        embed = discord.Embed(
+            title=f"You've been banned from {member.guild.name}",
+            description=dm_reason,
+            color=discord.Color.blue()
+        )
+        try:
+            await member.send(embed=embed)
+        except discord.Forbidden:
+            pass
+
+    await member.ban(reason=modlog_reason, delete_message_days=delete_message_days)
+
+    add_to_modlog(
+        None,
+        [member, member.guild],
+        'Ban',
+        modlog_reason,
+        silent,
+        None
+    )
+
+    if length:
+        days, hours = length
+        time_string = f"{days}d{hours}h"
+        default_config = {'enable': False, 'channel': None, 'timed_bans': {}}
+        config = here.bot.db['bans'].setdefault(str(member.guild.id), default_config)
+        timed_bans = config.setdefault('timed_bans', {})
+        timed_bans[str(member.id)] = time_string
 
 def parse_time(
         time_in: str,


### PR DESCRIPTION
- Removed the timeout option from `/spam_enable` slash command. By default, it now applies a 1-week timeout.
- Removed the `Solved` button to enable automatic banning of the user.
- Added a default ban reason "Hacked account..." along with instructions on how to appeal.
- Added a new `auto_ban` function in `helper_functions.py` to handle user bans and log the incident in the modlog.